### PR TITLE
Reset attributeValue for each use during product export

### DIFF
--- a/Writer/File/Csv/ProductAdvancedWriter.php
+++ b/Writer/File/Csv/ProductAdvancedWriter.php
@@ -207,7 +207,9 @@ class ProductAdvancedWriter extends AbstractItemMediaWriter implements
             $originalItem = $item;
             foreach ($item as $attributeKey => $attributeValue) {
                 $keepCurrentAttribute = false;
+                $attributeBaseValue = $attributeValue;
                 foreach ($mapping[self::MAPPING_COLUMNS_KEY] as $columnMapping) {
+                    $attributeValue = $attributeBaseValue;
                     if ($attributeKey == $columnMapping[self::MAPPING_ATTRIBUTE_CODE_KEY]) {
                         $keepCurrentAttribute = true;
 


### PR DESCRIPTION
`$attributeValue` can be used multiple times but is altered at the first iteration.
I needed to get the original value for each iteration.

Is there any use to keep the altered version through the mapping?